### PR TITLE
Fixed betking.io login error.

### DIFF
--- a/DiceBot/PRC.cs
+++ b/DiceBot/PRC.cs
@@ -364,7 +364,7 @@ namespace DiceBot
                 Parent.updateWins(tmp.Wins);
                 //Parent.updateDeposit(tmp.DepositAddress);
                 
-                getHeaders = HttpWebRequest.Create("https://betking.io/account/GetCurrentSeed") as HttpWebRequest;
+                getHeaders = HttpWebRequest.Create("https://betking.io/account/GetCurrentSeed?gameType=0") as HttpWebRequest;
                 if (Prox != null)
                     getHeaders.Proxy = Prox;
                 getHeaders.CookieContainer = Cookies;


### PR DESCRIPTION
Fixed failure when logging in to Betking.io. The lacking GET parameter "gameType" was causing a HTTP 500 error.