### PR TITLE
Fix 2FA Login for DuckDice

### DIFF
--- a/DiceBot/DuckDice.cs
+++ b/DiceBot/DuckDice.cs
@@ -238,7 +238,14 @@ namespace DiceBot
             try
             {
                 
-                StringContent Content = new StringContent("{\"username\":\"" + Username + "\",\"password\":\"" + Password + "\",\"campaignHash\":\"53ea652da4\"}", Encoding.UTF8, "application/json");
+                StringContent Content;
+                if (twofa != null)
+                {
+                    Content = new StringContent("{\"username\":\"" + Username + "\",\"password\":\"" + Password + "\",\"code\":\"" + twofa + "\",\"campaignHash\":\"53ea652da4\"}", Encoding.UTF8, "application/json");
+                } else
+                {
+                    Content = new StringContent("{\"username\":\"" + Username + "\",\"password\":\"" + Password + "\",\"campaignHash\":\"53ea652da4\"}", Encoding.UTF8, "application/json");
+                }
                 string sEmitResponse = Client.PostAsync("login" + accesstoken, Content).Result.Content.ReadAsStringAsync().Result;
                 QuackLogin tmplogin = null;
                 try


### PR DESCRIPTION
Enable users to login if they have 2FA enabled on their DuckDice.io account.

If the user provides a 2FA token value, we'll send it along with their username/password details to attempt login.
If no token value provided (ie. 2FA disabled), attempt login using only username/password.