### PR TITLE
Fix Reset Chart button crash

### DIFF
--- a/DiceBot/cDiceBot.cs
+++ b/DiceBot/cDiceBot.cs
@@ -5235,8 +5235,8 @@ namespace DiceBot
             Chartprofit = 0;
             chrtEmbeddedLiveChart.Series[0].Points.Clear();
             chartbets = 0;
-            chrtEmbeddedLiveChart.ChartAreas[0].AxisY.Minimum = 0;
-            chrtEmbeddedLiveChart.ChartAreas[0].AxisY.Maximum = 0;
+            //chrtEmbeddedLiveChart.ChartAreas[0].AxisY.Minimum = 0;
+            //chrtEmbeddedLiveChart.ChartAreas[0].AxisY.Maximum = 0;
             //chrtEmbeddedLiveChart.Series[0].Points.AddXY(0, 0);
             
         }


### PR DESCRIPTION
Don't force AxisY to a specific min or max, after "Reset Chart" button is used. This is to prevent an Auto Interval incorrect value Exception from occurring.

By leaving the Axis values alone, the chart will automagically resize as required (and intended).