### PR TITLE
Fix chart scale not resetting immediately

### DIFF
--- a/DiceBot/cDiceBot.cs
+++ b/DiceBot/cDiceBot.cs
@@ -5235,8 +5235,8 @@ namespace DiceBot
             Chartprofit = 0;
             chrtEmbeddedLiveChart.Series[0].Points.Clear();
             chartbets = 0;
-            //chrtEmbeddedLiveChart.ChartAreas[0].AxisY.Minimum = 0;
-            //chrtEmbeddedLiveChart.ChartAreas[0].AxisY.Maximum = 0;
+            chrtEmbeddedLiveChart.ChartAreas[0].AxisY.Minimum = Double.NaN;
+            chrtEmbeddedLiveChart.ChartAreas[0].AxisY.Maximum = Double.Nan;
             //chrtEmbeddedLiveChart.Series[0].Points.AddXY(0, 0);
             
         }


### PR DESCRIPTION
If using a currency like DOGE which generally operates with large numbers > 1 and then switch to a currency like BTC which tends to operate in fractional numbers under 1 (eg. 0.01 etc), the scale of the Y Axis on the chart will not reset properly, even when "Reset Chart" is pressed, until 1000 bets are reached. The Y-Min and Y-Max will remain at the "autoscaled values" for the previous larger numbers.

The default values on chart initialisation for Y Axis Min and Max are "NaN", so by resetting them to this value, we can simulate the chart being re-initialised and the AutoScale will work as intended from the first bet following the reset button being pressed.